### PR TITLE
Add determiner before the noun phrase

### DIFF
--- a/src/webgl/interaction.js
+++ b/src/webgl/interaction.js
@@ -16,7 +16,7 @@ import * as constants from '../core/constants';
  * from the center of the sketch. This function can be called with parameters
  * dictating sensitivity to mouse movement along the X and Y axes.  Calling
  * this function without parameters is equivalent to calling orbitControl(1,1).
- * To reverse direction of movement in either axis, enter a negative number
+ * To reverse the direction of movement in either axis, enter a negative number
  * for sensitivity.
  * @method orbitControl
  * @for p5


### PR DESCRIPTION
the noun: direction in line 19 was missing "the" before it

<!--
  Thank you for contributing! Please use this pull request (PR) template.


 In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing. If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".-->

 Changes: Added the determiner "the" before "direction"
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->




#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [ x] `npm run lint` passes
- [x ] [Inline documentation] is included / updated
- [ ] [Unit tests] are included / updated

[Inline documentation]: https://github.com/processing/p5.js/blob/main/contributor_docs/inline_documentation.md
[Unit tests]: https://github.com/processing/p5.js/tree/main/contributor_docs#unit-tests
